### PR TITLE
fix error: Class 'PHPHub\Jobs\SaveTopic' not found

### DIFF
--- a/database/seeds/TopicsSeeder.php
+++ b/database/seeds/TopicsSeeder.php
@@ -2,13 +2,11 @@
 
 use Illuminate\Database\Seeder;
 use Illuminate\Foundation\Bus\DispatchesJobs;
-use PHPHub\Jobs\SaveTopic;
 use PHPHub\Node;
 use PHPHub\User;
 
 class TopicsSeeder extends Seeder
 {
-    use DispatchesJobs;
 
     /**
      * Run the database seeds.

--- a/database/seeds/TopicsSeeder.php
+++ b/database/seeds/TopicsSeeder.php
@@ -6,7 +6,6 @@ use PHPHub\User;
 
 class TopicsSeeder extends Seeder
 {
-
     /**
      * Run the database seeds.
      */

--- a/database/seeds/TopicsSeeder.php
+++ b/database/seeds/TopicsSeeder.php
@@ -1,7 +1,6 @@
 <?php
 
 use Illuminate\Database\Seeder;
-use Illuminate\Foundation\Bus\DispatchesJobs;
 use PHPHub\Node;
 use PHPHub\User;
 

--- a/database/seeds/TopicsSeeder.php
+++ b/database/seeds/TopicsSeeder.php
@@ -28,7 +28,7 @@ class TopicsSeeder extends Seeder
         foreach ($topics as $topic) {
             $topic->user_id = array_rand($user_ids, 1);
             $topic->node_id = array_rand($node_ids, 1);
-            $this->dispatch(new SaveTopic($topic));
+            $topic->save();
         }
     }
 }


### PR DESCRIPTION
When I try `php artisan migrate:refresh --seed`, cmd appears 
`[Symfony\Component\Debug\Exception\FatalThrowableError]
  Fatal error: Class 'PHPHub\Jobs\SaveTopic' not found`